### PR TITLE
Move step computation into apply_grad().

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -23,12 +23,12 @@ class Model(object):
         loss = self.loss.loss(preds, targets)
         grad = self.loss.grad(preds, targets)
         grads = self.net.backward(grad)
-        params = self.net.get_parameters()
-        step = self.optimizer.compute_step(grads, params)
-        return loss, step
+        return loss, grads
 
     def apply_grad(self, grads):
-        for grad, (param, _) in zip(grads, self.net.get_params_and_grads()):
+        params = self.net.get_parameters()
+        steps = self.optimizer.compute_step(grads, params)
+        for grad, (param, _) in zip(steps, self.net.get_params_and_grads()):
             for k, v in param.items():
                 param[k] += grad[k]
 

--- a/core/model.py
+++ b/core/model.py
@@ -28,9 +28,9 @@ class Model(object):
     def apply_grad(self, grads):
         params = self.net.get_parameters()
         steps = self.optimizer.compute_step(grads, params)
-        for grad, (param, _) in zip(steps, self.net.get_params_and_grads()):
+        for step, (param, _) in zip(steps, self.net.get_params_and_grads()):
             for k, v in param.items():
-                param[k] += grad[k]
+                param[k] += step[k]
 
     def save(self, path):
         with open(path, "wb") as f:


### PR DESCRIPTION
In this way model.backward() only returns gradients
so that we can manipulate gradients directly. It is useful
when user finds mini-batch cannot fit into memory so they
want to accumulate gradients in smaller mini-batches and
apply gradients later to achieve the same effect as larger
mini-batches could achieve.