### PR TITLE
Remove unnecessary code.

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -24,7 +24,7 @@ class Model(object):
     def apply_grad(self, grads):
         params = self.net.get_parameters()
         steps = self.optimizer.compute_step(grads, params)
-        for step, (param, _) in zip(steps, self.net.get_params_and_grads()):
+        for step, param in zip(steps, params):
             for k, v in param.items():
                 param[k] += step[k]
 

--- a/core/nn.py
+++ b/core/nn.py
@@ -19,10 +19,6 @@ class Net(object):
             all_grads.append(layer.grads)
         return all_grads[::-1]
 
-    def get_params_and_grads(self):
-        for layer in self.layers:
-            yield layer.params, layer.grads
-
     def get_parameters(self):
         return [layer.params for layer in self.layers]
 


### PR DESCRIPTION
The net.get_params_and_grads() is redundant since
the gradients are returned when invoking backward.