### PR TITLE
remove model.load checking.

### DIFF
--- a/core/model.py
+++ b/core/model.py
@@ -29,21 +29,11 @@ class Model(object):
     def save(self, path):
         with open(path, "wb") as f:
             pickle.dump(self.net, f, -1)
-        print("Model saved in %s." % path)
 
     def load(self, path):
-        # compatibility checking
         with open(path, "rb") as f:
             net = pickle.load(f)
-        for l1, l2 in zip(self.net.layers, net.layers):
-            if l1.shape != l2.shape:
-                raise ValueError("Incompatible architecture. %s in loaded model"
-                                 " and %s in defined model." %
-                                 (l1.shape, l2.shape))
-            else:
-                print("%s: %s" % (l1.name, l1.shape))
         self.net = net
-        print("Restored model from %s." % path)
 
     def get_phase(self):
         return self.net.get_phase()


### PR DESCRIPTION
1. The current checking does not work because layers like Relu
   does not have shape/shapes.
2. The network shape can be undetermined (e.g., input length)
   before the net.forward function is invoked.

Remove this checking for now, later we can improve this. For now
it is a great idea to keep this simple.